### PR TITLE
Add tracking to the slash on commands

### DIFF
--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -22,7 +22,19 @@ export default function NavBar() {
       ) : (
         <>
           <div className="flex items-center text-white flex md:px-5">
-            <a href="https://www.warp.dev" target="_blank" rel="noreferrer">
+            <a
+              href="https://www.warp.dev"
+              target="_blank"
+              rel="noreferrer"
+              onClick={(e) => {
+                gtag.event({
+                  action: "click_on_slash_landing_page",
+                  category: "Click on Landing Page",
+                  label: "Click on Landing Page via Command Slash",
+                  value: window.location.pathname,
+                });
+              }}
+            >
               <LogoIcon />
             </a>
             <Link href="/">


### PR DESCRIPTION
Just realized that the slash here is a link to warp. Adding analytics tracking there.
![image](https://user-images.githubusercontent.com/24448704/159379640-c601fde7-0c5d-4c17-804d-3145ce7696a0.png)
