### PR TITLE
Clear algolia index before updating workflows

### DIFF
--- a/lib/build-search.ts
+++ b/lib/build-search.ts
@@ -34,6 +34,10 @@ import { getSortedWorkflowsData } from "./workflows";
 
     // Initialize the index with the algolia index name we set up
     const index = client.initIndex("workflow_specs");
+    
+    // Clear all objects before rewriting to remove specs that were deleted
+    // from the Algolia index.
+    index.clearObjects();
 
     // Save the objects
     const algoliaResponse = await index.saveObjects(transformed);


### PR DESCRIPTION
There was a small bug that was causing workflows that were _deleted_  to appear in the Algolia index. 

The reason this was happening was because the index never cleared any results from the index, it only appended. As a simple fix, clear all values from the index before rewriting, as the workflows repo is always the source of truth for workflows