### PR TITLE
Add URL query parameter support for search

### DIFF
--- a/components/search/CustomSearchBox.tsx
+++ b/components/search/CustomSearchBox.tsx
@@ -10,6 +10,7 @@ interface SearchBoxProps {
 
 function SearchBox({ refine }: SearchBoxProps) {
   const [searchBarState, setSearchBarState] = useState("");
+  const router = useRouter();
   useHotkeys("ctrl+k", () => {
     if (document != null) {
       const searchBar = document.querySelector(
@@ -21,8 +22,21 @@ function SearchBox({ refine }: SearchBoxProps) {
     }
   });
 
-  const dynamicRoute = useRouter().asPath;
+  // Populate search from ?query= URL parameter on initial load
+  const [initialQueryApplied, setInitialQueryApplied] = useState(false);
   useEffect(() => {
+    if (initialQueryApplied || !router.isReady) return;
+    const urlQuery = router.query.query;
+    if (typeof urlQuery === "string" && urlQuery.length > 0) {
+      setSearchBarState(urlQuery);
+      refine(urlQuery);
+    }
+    setInitialQueryApplied(true);
+  }, [router.isReady, router.query.query, initialQueryApplied, refine]);
+
+  const dynamicRoute = router.asPath;
+  useEffect(() => {
+    if (!initialQueryApplied) return;
     refine(""); // When the route changes - reset the search state
     setSearchBarState("");
   }, [dynamicRoute, refine]);
@@ -39,8 +53,16 @@ function SearchBox({ refine }: SearchBoxProps) {
         value={searchBarState}
         placeholder={"Ctrl + K"}
         onChange={(e) => {
-          refine(e.currentTarget.value);
-          setSearchBarState(e.currentTarget.value);
+          const value = e.currentTarget.value;
+          refine(value);
+          setSearchBarState(value);
+          const url = new URL(window.location.href);
+          if (value) {
+            url.searchParams.set("query", value);
+          } else {
+            url.searchParams.delete("query");
+          }
+          window.history.replaceState({}, "", url.toString());
         }}
         className="grow h-9 cursor-pointer rounded-sm text-sm focus:outline-none dark:bg-card-dark bg-search-bar-light placeholder:opacity-50 dark:text-white px-2"
       />

--- a/components/search/MobileSearchBox.tsx
+++ b/components/search/MobileSearchBox.tsx
@@ -13,6 +13,7 @@ function SearchBox({
   onCloseCallback,
 }: MobileSearchBoxProps) {
   const [searchBarState, setSearchBarState] = useState("");
+  const router = useRouter();
   useEffect(() => {
     const searchBar = document.querySelector(
       "#algolia_search"
@@ -22,8 +23,21 @@ function SearchBox({
     }
   }, []);
 
-  const dynamicRoute = useRouter().asPath;
+  // Populate search from ?query= URL parameter on initial load
+  const [initialQueryApplied, setInitialQueryApplied] = useState(false);
   useEffect(() => {
+    if (initialQueryApplied || !router.isReady) return;
+    const urlQuery = router.query.query;
+    if (typeof urlQuery === "string" && urlQuery.length > 0) {
+      setSearchBarState(urlQuery);
+      refine(urlQuery);
+    }
+    setInitialQueryApplied(true);
+  }, [router.isReady, router.query.query, initialQueryApplied, refine]);
+
+  const dynamicRoute = router.asPath;
+  useEffect(() => {
+    if (!initialQueryApplied) return;
     refine(""); // When the route changes - reset the search state
     setSearchBarState("");
   }, [dynamicRoute, refine]);
@@ -37,8 +51,16 @@ function SearchBox({
         placeholder={"Search commands"}
         value={searchBarState}
         onChange={(e) => {
-          refine(e.currentTarget.value);
-          setSearchBarState(e.currentTarget.value);
+          const value = e.currentTarget.value;
+          refine(value);
+          setSearchBarState(value);
+          const url = new URL(window.location.href);
+          if (value) {
+            url.searchParams.set("query", value);
+          } else {
+            url.searchParams.delete("query");
+          }
+          window.history.replaceState({}, "", url.toString());
         }}
         className="grow h-9 cursor-pointer text-sm focus:outline-none bg-inherit placeholder:opacity-50 text-black dark:text-white px-2"
       />


### PR DESCRIPTION
## Summary
- Parse `?query=` URL parameter on page load and populate the search input, triggering an Algolia search
- Update the URL query parameter as the user types, enabling shareable/bookmarkable search links (e.g. `commands.dev/?query=git`)

## Why this matters
[#60](https://github.com/warpdotdev/commands.dev/issues/60) - Users want to share direct links to search results and query commands.dev from the address bar.

## Changes
- `components/search/CustomSearchBox.tsx`: Read `?query=` param on mount via Next.js router, set search state and call `refine()`; update URL on input change via `history.replaceState`
- `components/search/MobileSearchBox.tsx`: Same URL query parameter support for mobile search

## Test plan
- [ ] Visit `/?query=git` and verify the search input is populated with "git" and results are shown
- [ ] Type a search term and verify the URL updates to include `?query=<term>`
- [ ] Clear the search and verify `?query=` is removed from the URL
- [ ] Navigate to a different page and back - verify search resets correctly

Fixes #60

This contribution was developed with AI assistance (Claude Code).