### PR TITLE
fix: update picomatch to resolve CVE-2026-33672

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5341,9 +5341,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6575,9 +6575,9 @@
       }
     },
     "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "peer": true,


### PR DESCRIPTION
## Summary
- Updates transitive `picomatch` lockfile entries to patched versions for CVE-2026-33672.
- Resolves both vulnerable dependency ranges currently present in `package-lock.json`:
  - `picomatch` 2.x: `2.3.1` -> `2.3.2`
  - `picomatch` 4.x under `tinyglobby`: `4.0.3` -> `4.0.4`

## Vulnerability details
- Advisory: https://github.com/advisories/GHSA-3v7f-55p6-f55p
- CVE: CVE-2026-33672
- Dependabot alerts:
  - https://github.com/warpdotdev/commands.dev/security/dependabot/63
  - https://github.com/warpdotdev/commands.dev/security/dependabot/66
- Dependency relationship: transitive development dependency via `package-lock.json`.
- Workaround applied: none; existing semver ranges already allowed the patched releases, so this is a lockfile-only update.

## Verification
- `npm audit --json` no longer reports `picomatch` / GHSA-3v7f-55p6-f55p. Remaining audit findings are unrelated and covered separately.
- `npm run lint`
- `npx tsc lib/*.ts`
- `NEXT_PUBLIC_ALGOLIA_APP_ID=dummy NEXT_PUBLIC_ALGOLIA_SEARCH_API_KEY=dummy npx next build`

_Conversation: https://staging.warp.dev/conversation/550fab81-e5b7-4938-ab82-c93ffa1e7e21_
_Run: https://oz.staging.warp.dev/runs/019e36aa-77c6-72a5-a14f-feba903dc2f2_
_This PR was generated with [Oz](https://warp.dev/oz)._
