### PR TITLE
fix: update qs to resolve CVE-2026-8723

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5387,7 +5387,6 @@
       "version": "8.5.10",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
       "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -5588,9 +5587,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
-      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"


### PR DESCRIPTION
## Summary
- Updates transitive npm dependency `qs` from `6.15.0` to `6.15.2` in `package-lock.json`.
- Resolves `CVE-2026-8723` / `GHSA-q8mj-m7cp-5q26`, a remotely triggerable DoS in `qs.stringify`.
- Dependency path: `react-instantsearch -> instantsearch.js -> qs`.

## Dependabot alert
- https://github.com/warpdotdev/commands.dev/security/dependabot/99

## Advisory
- https://github.com/ljharb/qs/security/advisories/GHSA-q8mj-m7cp-5q26
- https://nvd.nist.gov/vuln/detail/CVE-2026-8723

## Verification
- `npm ls qs --package-lock-only --all` shows `qs@6.15.2`.
- `npm audit --json` no longer reports `qs`.
- `npm run lint` passes.
- `NEXT_PUBLIC_ALGOLIA_APP_ID=dummy NEXT_PUBLIC_ALGOLIA_SEARCH_API_KEY=dummy ALGOLIA_SEARCH_ADMIN_KEY=dummy npx tsc lib/*.ts && NEXT_PUBLIC_ALGOLIA_APP_ID=dummy NEXT_PUBLIC_ALGOLIA_SEARCH_API_KEY=dummy ALGOLIA_SEARCH_ADMIN_KEY=dummy npx next build` passes.

Note: `npm run build` invokes the repo's `postbuild` Algolia publishing script. With placeholder Algolia values it reaches the external publish step and fails DNS lookup for the dummy app id, so the underlying TypeScript and Next build commands were run directly for validation.

_Conversation: https://staging.warp.dev/conversation/25d363f7-d567-4b61-84b7-5ca0bcf37fd0_
_Run: https://oz.staging.warp.dev/runs/019e799d-2a32-71bf-8859-6b02d8930e6d_
_This PR was generated with [Oz](https://warp.dev/oz)._
